### PR TITLE
Add find command to include finding Address of a person

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -6,6 +6,8 @@ import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
+import java.util.function.Predicate;
+
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
@@ -19,9 +21,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,11 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,23 +3,35 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
-
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<property>\\S+)(?<arguments>.*)");
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
+        args = args.trim();
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(args.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String property = matcher.group("property").trim();
+        final String trimmedArgs = matcher.group("arguments").trim();
+
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -27,7 +39,14 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (property.equals("a")) {
+            return new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        } else if (property.equals("n")) {
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
     }
 
 }

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,10 +1,14 @@
 package seedu.address.model.person;
 
+import java.util.function.Predicate;
+import java.util.List;
+
 import seedu.address.commons.util.StringUtil;
 
-import java.util.List;
-import java.util.function.Predicate;
 
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
 public class AddressContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,7 +1,8 @@
 package seedu.address.model.person;
 
-import java.util.function.Predicate;
 import java.util.List;
+import java.util.function.Predicate;
+
 
 import seedu.address.commons.util.StringUtil;
 

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class AddressContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddressContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((AddressContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -57,27 +58,50 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+
+        String expectedMessage2 = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        AddressContainsKeywordsPredicate predicate2 = prepareAddressPredicate(" ");
+        FindCommand command2 = new FindCommand(predicate2);
+        expectedModel.updateFilteredPersonList(predicate2);
+        assertCommandSuccess(command2, model, expectedMessage2, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+
     }
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        String expectedMessage1 = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        NameContainsKeywordsPredicate predicate1 = prepareNamePredicate("Kurz Elle Kunz");
+        FindCommand command = new FindCommand(predicate1);
+        expectedModel.updateFilteredPersonList(predicate1);
+        assertCommandSuccess(command, model, expectedMessage1, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+
+        String expectedMessage2 = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        AddressContainsKeywordsPredicate predicate2 = prepareAddressPredicate("tokyo");
+        FindCommand command2 = new FindCommand(predicate2);
+        expectedModel.updateFilteredPersonList(predicate2);
+        assertCommandSuccess(command2, model, expectedMessage2, expectedModel);
+        assertEquals(Arrays.asList(FIONA), model.getFilteredPersonList());
+    }
+
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
+        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private AddressContainsKeywordsPredicate prepareAddressPredicate(String userInput) {
+        return new AddressContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -38,7 +38,7 @@ public class TypicalPersons {
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little c tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street").build();
 


### PR DESCRIPTION
Needs to be implemented so that we may search for health conditions/medicine usage in future.

Needs to include 'a'/'n' to indicate address attribute or name attribute before the actual arguments. Eg. "find n Bernice" will return all persons that contain the string "bernice"(case insensitive) in their names.

It is done this way to differentiate the different attributes that we might search for in future. Can be edit in future to improve the syntax of commands.